### PR TITLE
Fix blank GitHub Pages site

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,10 @@ const dirname = typeof import.meta.dirname !== "undefined"
   : path.dirname(fileURLToPath(import.meta.url));
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
+const base = process.env.NODE_ENV === "production" ? "/how-things-work/" : "/";
+
 export default defineConfig({
+  base,
   plugins: [
     react(),
     runtimeErrorOverlay(),


### PR DESCRIPTION
## Summary
- configure Vite to use the repo subpath when NODE_ENV is production

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846b1a437b48320845a792116da4949