### PR TITLE
Fix routing for GitHub Pages

### DIFF
--- a/client/public/404.html
+++ b/client/public/404.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; url=./" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { Switch, Route } from "wouter";
+import { Switch, Route, Router as WouterRouter } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
@@ -13,7 +13,7 @@ import ParentZone from "@/pages/parent-zone";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
 
-function Router() {
+function Routes() {
   return (
     <div className="min-h-screen bg-alice-blue exploration-bg">
       <Header />
@@ -38,7 +38,9 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <Toaster />
-        <Router />
+        <WouterRouter base={import.meta.env.BASE_URL.replace(/\/$/, "")}>
+          <Routes />
+        </WouterRouter>
       </TooltipProvider>
     </QueryClientProvider>
   );


### PR DESCRIPTION
## Summary
- configure wouter router to respect `import.meta.env.BASE_URL`
- include a 404.html redirect so direct links to sub paths work

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6846bc2495e0832094c4f8c0111aeb5f