### PR TITLE
Use configurable API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL for the backend API. Leave empty to use the same origin.
+VITE_API_BASE_URL=https://how-things-work.onrender.com

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+.env

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ GitHub Pages can host only static files, so you can deploy the **frontend** ther
    ```
 4. In your GitHub repository settings, enable GitHub Pages and select the `gh-pages` branch as the source.
 
-After the branch is published, GitHub Pages will serve the static client. Configure your frontend to call the URL where the Express server is hosted.
+After the branch is published, GitHub Pages will serve the static client. Set the `VITE_API_BASE_URL` environment variable in the frontend build to the URL where the Express server is hosted so API requests resolve correctly.
 
 ### Fixing Routing on GitHub Pages
 

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,5 +1,9 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
 
+// Prefix all API requests with this base URL. When deployed separately from the
+// backend, set VITE_API_BASE_URL in the environment (e.g. "https://how-things-work.onrender.com").
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
+
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     const text = (await res.text()) || res.statusText;
@@ -12,7 +16,7 @@ export async function apiRequest(
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
-  const res = await fetch(url, {
+  const res = await fetch(`${API_BASE}${url}`, {
     method,
     headers: data ? { "Content-Type": "application/json" } : {},
     body: data ? JSON.stringify(data) : undefined,
@@ -29,7 +33,7 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey[0] as string, {
+    const res = await fetch(`${API_BASE}${queryKey[0] as string}`, {
       credentials: "include",
     });
 


### PR DESCRIPTION
## Summary
- allow `VITE_API_BASE_URL` to prefix all API calls
- document API base URL usage
- ignore local `.env` files and provide an example file

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6846dbe283988320b9a3223b23bc340f