### PR TITLE
Switch heading fonts to Oswald

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;700&display=swap" rel="stylesheet" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -67,7 +67,7 @@
   }
 
   h1, h2, h3, h4, h5, h6 {
-    font-family: 'Comic Neue', cursive;
+    font-family: 'Oswald', sans-serif;
   }
 }
 
@@ -145,7 +145,7 @@
   }
 
   .font-comic {
-    font-family: 'Comic Neue', cursive;
+    font-family: 'Oswald', sans-serif;
   }
 }
 


### PR DESCRIPTION
## Summary
- use Oswald for all h1-h6 styles and custom `font-comic` class
- include Oswald Google Fonts link in `index.html`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684725db83448320bbfb195a8e947d16